### PR TITLE
feat(convert): add ToPtr function to convert types to pointers

### DIFF
--- a/convert/default.go
+++ b/convert/default.go
@@ -36,3 +36,10 @@ func ToString(a any, defaultValue string) string {
 	}
 	return val
 }
+
+// ToPtr converts a value to a pointer of the same type
+// Example: ToPtr("hello") returns *string with value "hello"
+// Example: ToPtr(42) returns *int with value 42
+func ToPtr[T any](v T) *T {
+	return &v
+}

--- a/convert/default_test.go
+++ b/convert/default_test.go
@@ -59,6 +59,100 @@ func TestToInt(t *testing.T) {
 	}
 }
 
+func TestToPtr(t *testing.T) {
+	t.Run("string to *string", func(t *testing.T) {
+		val := "hello"
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != "hello" {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, "hello")
+		}
+	})
+
+	t.Run("int to *int", func(t *testing.T) {
+		val := 42
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != 42 {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, 42)
+		}
+	})
+
+	t.Run("float64 to *float64", func(t *testing.T) {
+		val := 3.14
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != 3.14 {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, 3.14)
+		}
+	})
+
+	t.Run("bool to *bool", func(t *testing.T) {
+		val := true
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != true {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, true)
+		}
+	})
+
+	t.Run("zero value int to *int", func(t *testing.T) {
+		val := 0
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != 0 {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, 0)
+		}
+	})
+
+	t.Run("zero value string to *string", func(t *testing.T) {
+		val := ""
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if *ptr != "" {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, "")
+		}
+	})
+
+	t.Run("struct to *struct", func(t *testing.T) {
+		type Person struct {
+			Name string
+			Age  int
+		}
+		val := Person{Name: "John", Age: 30}
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if ptr.Name != "John" || ptr.Age != 30 {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, val)
+		}
+	})
+
+	t.Run("slice to *slice", func(t *testing.T) {
+		val := []int{1, 2, 3}
+		ptr := ToPtr(val)
+		if ptr == nil {
+			t.Error("ToPtr() returned nil pointer")
+		}
+		if len(*ptr) != 3 || (*ptr)[0] != 1 {
+			t.Errorf("ToPtr() = %v, want %v", *ptr, val)
+		}
+	})
+}
+
 func TestToString(t *testing.T) {
 	type args struct {
 		a            any

--- a/convert/example_test.go
+++ b/convert/example_test.go
@@ -1,0 +1,58 @@
+package convert
+
+import (
+	"fmt"
+)
+
+func ExampleToPtr() {
+	// Convert string to *string
+	str := "hello"
+	strPtr := ToPtr(str)
+	fmt.Println(*strPtr)
+
+	// Convert int to *int
+	num := 42
+	numPtr := ToPtr(num)
+	fmt.Println(*numPtr)
+
+	// Convert float64 to *float64
+	pi := 3.14
+	piPtr := ToPtr(pi)
+	fmt.Println(*piPtr)
+
+	// Convert bool to *bool
+	flag := true
+	flagPtr := ToPtr(flag)
+	fmt.Println(*flagPtr)
+
+	// Output:
+	// hello
+	// 42
+	// 3.14
+	// true
+}
+
+func ExampleToPtr_struct() {
+	type Person struct {
+		Name string
+		Age  int
+	}
+
+	// Convert struct to *struct
+	person := Person{Name: "John", Age: 30}
+	personPtr := ToPtr(person)
+	fmt.Println(personPtr.Name, personPtr.Age)
+
+	// Output:
+	// John 30
+}
+
+func ExampleToPtr_slice() {
+	// Convert slice to *slice
+	numbers := []int{1, 2, 3}
+	numbersPtr := ToPtr(numbers)
+	fmt.Println((*numbersPtr)[0], (*numbersPtr)[1], (*numbersPtr)[2])
+
+	// Output:
+	// 1 2 3
+}


### PR DESCRIPTION
- Add generic ToPtr function using Go generics
- Convert any type to pointer of the same type
- Examples: string -> *string, int -> *int, etc.
- Support for all types: primitives, structs, slices, etc.
- 100% test coverage
- Add comprehensive tests and examples

Usage:
  strPtr := ToPtr("hello")  // *string
  intPtr := ToPtr(42)         // *int
  boolPtr := ToPtr(true)      // *bool

Closes #37